### PR TITLE
Speed up entrance rules and remove intermediate entrance regions

### DIFF
--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -35,6 +35,7 @@ from .randomizers.Entrances import (
     SECRET_CAVE_ENTRANCES,
     SECRET_CAVE_INNER_ENTRANCES,
     EntranceRandomizer,
+    ZoneEntrance,
 )
 from .randomizers.ItemPool import generate_itempool
 from .randomizers.RequiredBosses import RequiredBossesRandomizer
@@ -259,9 +260,9 @@ class TWWWorld(World):
         Create and connect all the necessary regions in the multiworld and establish the access rules for entrances.
         """
 
-        def get_access_rule(region: str) -> str:
-            snake_case_region = region.lower().replace("'", "").replace(" ", "_")
-            return f"can_access_{snake_case_region}"
+        def get_access_rule(zone_entrance: ZoneEntrance) -> str:
+            snake_case_region = zone_entrance.entrance_name.lower().replace("'", "").replace(" ", "_")
+            return getattr(Macros, f"can_access_{snake_case_region}")
 
         multiworld = self.multiworld
         player = self.player
@@ -280,9 +281,7 @@ class TWWWorld(World):
         for entrance in DUNGEON_ENTRANCES + SECRET_CAVE_ENTRANCES + FAIRY_FOUNTAIN_ENTRANCES:
             great_sea_region.connect(
                 self.get_region(entrance.entrance_name),
-                rule=lambda state, entrance=entrance.entrance_name: getattr(Macros, get_access_rule(entrance))(
-                    state, player
-                ),
+                rule=lambda state, rule=get_access_rule(entrance): rule(state, player),
             )
 
         # Connect nested regions with their parent region.
@@ -294,9 +293,7 @@ class TWWWorld(World):
             parent_region = self.get_region(parent_region_name)
             parent_region.connect(
                 self.get_region(entrance.entrance_name),
-                rule=lambda state, entrance=entrance.entrance_name: getattr(Macros, get_access_rule(entrance))(
-                    state, player
-                ),
+                rule=lambda state, rule=get_access_rule(entrance): rule(state, player),
             )
 
     def create_regions(self) -> None:

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -35,7 +35,6 @@ from .randomizers.Entrances import (
     SECRET_CAVE_ENTRANCES,
     SECRET_CAVE_INNER_ENTRANCES,
     EntranceRandomizer,
-    ZoneEntrance,
 )
 from .randomizers.ItemPool import generate_itempool
 from .randomizers.RequiredBosses import RequiredBossesRandomizer
@@ -257,12 +256,9 @@ class TWWWorld(World):
 
     def setup_base_regions(self) -> None:
         """
-        Create and connect all the necessary regions in the multiworld and establish the access rules for entrances.
+        Create all the necessary regions in the multiworld. Connections between regions are added later, after any
+        entrance randomization.
         """
-
-        def get_access_rule(zone_entrance: ZoneEntrance) -> str:
-            snake_case_region = zone_entrance.entrance_name.lower().replace("'", "").replace(" ", "_")
-            return getattr(Macros, f"can_access_{snake_case_region}")
 
         multiworld = self.multiworld
         player = self.player
@@ -272,29 +268,8 @@ class TWWWorld(World):
         multiworld.regions.append(great_sea_region)
 
         # Add all randomizable regions.
-        for _entrance in ALL_ENTRANCES:
-            multiworld.regions.append(Region(_entrance.entrance_name, player, multiworld))
         for _exit in ALL_EXITS:
             multiworld.regions.append(Region(_exit.unique_name, player, multiworld))
-
-        # Connect the dungeon, secret caves, and fairy fountain regions to the "The Great Sea" region.
-        for entrance in DUNGEON_ENTRANCES + SECRET_CAVE_ENTRANCES + FAIRY_FOUNTAIN_ENTRANCES:
-            great_sea_region.connect(
-                self.get_region(entrance.entrance_name),
-                rule=lambda state, rule=get_access_rule(entrance): rule(state, player),
-            )
-
-        # Connect nested regions with their parent region.
-        for entrance in MINIBOSS_ENTRANCES + BOSS_ENTRANCES + SECRET_CAVE_INNER_ENTRANCES:
-            parent_region_name = entrance.entrance_name.split(" in ")[-1]
-            # Consider Hyrule Castle and Forsaken Fortress as part of The Great Sea (regions are not randomizable).
-            if parent_region_name in ["Hyrule Castle", "Forsaken Fortress"]:
-                parent_region_name = "The Great Sea"
-            parent_region = self.get_region(parent_region_name)
-            parent_region.connect(
-                self.get_region(entrance.entrance_name),
-                rule=lambda state, rule=get_access_rule(entrance): rule(state, player),
-            )
 
     def create_regions(self) -> None:
         """
@@ -452,13 +427,8 @@ class TWWWorld(World):
                 output_data["Locations"][location.name] = item_info
 
         # Output the mapping of entrances to exits.
-        all_entrance_names = [en.entrance_name for en in ALL_ENTRANCES]
-        entrances = multiworld.get_entrances(player)
-        for entrance in entrances:
-            assert entrance.parent_region is not None
-            if entrance.parent_region.name in all_entrance_names:
-                assert entrance.connected_region is not None
-                output_data["Entrances"][entrance.parent_region.name] = entrance.connected_region.name
+        for zone_entrance, zone_exit in self.entrances.done_entrances_to_exits.items():
+            output_data["Entrances"][zone_entrance.entrance_name] = zone_exit.unique_name
 
         # Output the plando details to file.
         aptww = TWWContainer(

--- a/worlds/tww/randomizers/Entrances.py
+++ b/worlds/tww/randomizers/Entrances.py
@@ -618,9 +618,9 @@ class EntranceRandomizer:
         For all entrance-exit pairs, this function adds a connection with the appropriate access rule to the world.
         """
 
-        def get_access_rule(region: str) -> str:
-            snake_case_region = region.lower().replace("'", "").replace(" ", "_")
-            return f"can_access_{snake_case_region}"
+        def get_access_rule(entrance: ZoneEntrance) -> str:
+            snake_case_region = entrance.entrance_name.lower().replace("'", "").replace(" ", "_")
+            return getattr(Macros, f"can_access_{snake_case_region}")
 
         # Connect each entrance-exit pair in the multiworld with the access rule for the entrance.
         for zone_entrance, zone_exit in self.done_entrances_to_exits.items():
@@ -628,9 +628,7 @@ class EntranceRandomizer:
             exit_region = self.world.get_region(zone_exit.unique_name)
             entrance_region.connect(
                 exit_region,
-                rule=lambda state, entrance=entrance_region.name: getattr(Macros, get_access_rule(entrance))(
-                    state, self.player
-                ),
+                rule=lambda state, rule=get_access_rule(zone_entrance): rule(state, self.player),
             )
 
         if self.world.options.required_bosses:


### PR DESCRIPTION
A `ZoneEntrance -> ZoneExit` entrance randomization pair was connecting regions like `ZoneEntrance.parent_region -> ZoneEntrance -> ZoneExit`, when `ZoneEntrance.parent_region` could be connected to `ZoneExit` directly, removing the need for the intermediate `ZoneEntrance` region and one of the entrances.

Both of these entrances were even having the exact same access rule set.

Removing the extra regions and entrances increases generation speed.

The rule functions are now retrieved in advance so that each call to check each entrance's accessibility does not have to redo this work.

---

Generating seeds before and after these changes produced identical results. The order of the `ZoneEntrance -> ZoneExit` mapping written to the .aptww patch might have changed and I don't know if this is important in any way.

I have not tested whether the .aptww can be used to patch correctly, since I do not have a wwrando_ap-2.5.0 pre-release, but the patch file at least looked OK when unzipped it and base64-decoded the plando file and looked at the contents.